### PR TITLE
typo: code for "Detected" token

### DIFF
--- a/yeast2html
+++ b/yeast2html
@@ -50,7 +50,7 @@ my $code2class = {
     o   => { code => 'o', type => 'end',   title => "Document" },
     '!' => { code => '!', type => 'error', title => "Error" },
     '-' => { code => '-', type => 'text',  title => "Unparsed" },
-    '$' => { code => '-', type => 'text',  title => "Detected" },
+    '$' => { code => '$', type => 'text',  title => "Detected" },
     '~' => { code => '~', type => 'text',  title => "Empty" }
 };
 


### PR DESCRIPTION
I'm not 100% sure that this is an error but it at least looks to be.  There's apparently some special behavior (for debugging) set aside with this particular token so perhaps it is intentional to treat it as an Unparsed Token instead?  Thought I would make the suggestion, in any case.

thanks!